### PR TITLE
Added workaround for missing region eu-central-1

### DIFF
--- a/aws_minion/cli.py
+++ b/aws_minion/cli.py
@@ -37,6 +37,10 @@ from aws_minion.user_data import get_config_yaml
 from aws_minion.user_data import get_bash_script
 from aws_minion.utils import FloatRange, ComparableLooseVersion
 
+# FIXME: Workaround for open GitHub PR (missing region eu-central-1): https://github.com/boto/boto/pull/2976
+BOTO_ENDPOINTS = os.path.join(os.path.dirname(__file__), 'myendpoints.json')
+os.environ['BOTO_ENDPOINTS'] = BOTO_ENDPOINTS
+
 # FIXME: hardcoded for eu-west-1: Ubuntu Server 14.04 LTS (HVM), SSD Volume Type
 AMI_ID = 'ami-f0b11187'
 

--- a/aws_minion/myendpoints.json
+++ b/aws_minion/myendpoints.json
@@ -1,0 +1,8 @@
+{
+    "iam": {
+        "eu-central-1": "iam.amazonaws.com"
+    },
+    "route53": {
+        "eu-central-1": "route53.amazonaws.com"
+    }
+}


### PR DESCRIPTION
This is a workaround until https://github.com/boto/boto/pull/2976 is fixed.